### PR TITLE
Remove search path to fix gulp task.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 
 	<!-- Fix error with console.log not being available -->
 	<script type="text/javascript"> if (!window.console) console = {log: function() {}}; </script>
-	<!-- build:js(/) /js/concat/combined-globals.js -->
+	<!-- build:js /js/concat/combined-globals.js -->
 	<script type="text/javascript" src="/js/vendor/jquery.min.js"></script>
 	<script type="text/javascript" src="/js/vendor/modernizr.custom.js"></script>
 	<!-- endbuild -->

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
     "gulp-plumber": "^1.0.1",
     "gulp-rename": "1.2.0",
     "gulp-run": "^1.6.8",
-    "gulp-useref": "1.2.0",
+    "gulp-useref": "^2.0.0",
     "gulp-watch": "^4.2.4",
-    "lazypipe": "^0.2.2"
+    "lazypipe": "^0.2.2",
+    "mocha": "*",
+    "mock-gulp-dest": "^0.1.1"
   },
   "scripts": {
+    "test": "mocha",
     "update": "sudo npm install && bower install"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,21 @@
+var gulp = require('gulp'),
+    mockGulpDest = require('mock-gulp-dest')(gulp);
+
+// Load all slush generator tasks:
+require('./gulpfile');
+
+describe('gulpfile test', function() {
+  it('should generate project files', function(done) {
+    // Run the default task in the current slush generator:
+    gulp.start('js-concat')
+      .on('stop', function() {
+        // Multiple files as array:
+        mockGulpDest.assertDestContains([
+          'index.html',
+          'js/concat/combined-globals.js',
+        ]);
+
+        done();
+      });
+  });
+});


### PR DESCRIPTION
I created a test using a gulp mocking library and tested it with gulp-useref 1.2, 1.3 and 2.0.

Your task works with 1.2 but failed with 1.3 and 2.0 until I removed the search path. It passes now and the search path doesn't seem like it was needed.